### PR TITLE
Removed spurious check and print of tty status for STDIN after openin…

### DIFF
--- a/Linux_C/normal/serial.c
+++ b/Linux_C/normal/serial.c
@@ -6,14 +6,6 @@ int serial_open(unsigned char* dev, unsigned int baud)
     int fd;
     fd = open(dev, O_RDWR|O_NOCTTY); 
     if (fd < 0) return fd;
-    if(isatty(STDIN_FILENO)==0) 
-      {
-   	  printf("standard input is not a terminal device\n"); 
-      }   
-    else 
-      {
-	  printf("isatty success!\n"); 
-      }
 
     struct termios newtio,oldtio; 
     if (tcgetattr( fd,&oldtio) != 0) 


### PR DESCRIPTION
…g a device. This was presumably a debugging print left over, but it should probably have checked the dev rather than STDIN even in that case.

This avoids writing text to STDOUT that is not useful and may cause problems in some environments.